### PR TITLE
Refactor: Remove covidOnly checkbox from HealthCare Settings update screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5118,7 +5118,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -8904,7 +8903,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -8941,7 +8939,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -12165,7 +12162,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -15084,7 +15080,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -18129,6 +18124,21 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -18307,7 +18317,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"

--- a/src/Views/HealthCareSettings/HealthCareSettings.js
+++ b/src/Views/HealthCareSettings/HealthCareSettings.js
@@ -413,10 +413,13 @@ class HealthCareSettings extends Component {
       rowData["subscriptionsEnabled"] = e.target.checked;
       rowData["isChanged"] = true;
     }
-    if (columnType === "EnableCovidReporting") {
-      rowData["covidOnly"] = e.target.checked;
-      rowData["isChanged"] = true;
-    }
+    // if (columnType === "EnableCovidReporting") {
+    //   rowData["covidOnly"] = e.target.checked;
+    //   rowData["isChanged"] = true;
+    // }
+
+    rowData["isChanged"] = true;
+    rowData["covidOnly"] = false; // Reset covidOnly to false
 
     // eslint-disable-next-line
     this.state.selectedKARDetails.filter((x) => {
@@ -2483,20 +2486,17 @@ class HealthCareSettings extends Component {
                               >
                                 <tbody>
                                   <tr>
-                                    {/* <th>PlanDefinitionId</th> */}
                                     <th>Name</th>
                                     <th>Publisher</th>
                                     <th>Version</th>
                                     <th>Activate</th>
                                     <th>Enable Subscriptions</th>
-                                    <th>Emergent Reporting</th>
                                     <th className="outputFormat">
                                       Output Format
                                     </th>
                                   </tr>
                                   {this.state.selectedKARDetails.map((get) => (
                                     <tr key={get.karId}>
-                                      {/* <td>{get.karId}</td> */}
                                       <td className="karTableName">
                                         {get.karName}
                                       </td>
@@ -2533,22 +2533,7 @@ class HealthCareSettings extends Component {
                                           className="tableCheckboxes"
                                           checked={get.subscriptionsEnabled}
                                         />
-                                      </td>
-                                      <td className="karCheckBoxes">
-                                        <Form.Check
-                                          type="checkbox"
-                                          name="covidEnabled"
-                                          onChange={(e) =>
-                                            this.handleCheckboxChange(
-                                              e,
-                                              get,
-                                              "EnableCovidReporting"
-                                            )
-                                          }
-                                          className="tableCheckboxes"
-                                          checked={get.covidOnly}
-                                        />
-                                      </td>
+                                      </td>                                   
                                       <td>
                                         <Form.Control
                                           as="select"


### PR DESCRIPTION
This PR removes the covidOnly checkbox from the Update HealthCare Settings screen as it is no longer required.

**Changes Made:**
1. Removed the covidOnly checkbox from the HTML markup.
2. Removed all associated event handlers, bindings, and state logic related to covidOnly.
3. Ensured that the covidOnly field is set to false by default or consistently treated as false in the backend/API calls.