### PR TITLE
eCRNow-UI#33:  proxy settings cause error in development mode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
-  "proxy": "http://localhost:8081",
+  "options": {
+    "proxy": "http://localhost:8081",
+    "allowedHosts": ["localhost", ".localhost"]
+  },
   "eslintConfig": {
     "extends": "react-app"
   },


### PR DESCRIPTION
Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
 - options.allowedHosts[0] should be a non-empty string.

I don't mess with all the react-app stuff, but I think the requirement for the proxy setup must have changed.

I think allowedHosts is now required in package.json.



